### PR TITLE
Fix daemon spelling in docs

### DIFF
--- a/reaction/docs/reaction.1
+++ b/reaction/docs/reaction.1
@@ -131,7 +131,7 @@
 .IX Title "REACTION 1"
 .TH REACTION 1 "2005-12-28" "perl v5.8.5" "Reaction program manpage"
 .SH "NAME"
-reaction \- Deamon server multithread 
+reaction \- Daemon server multithread 
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 \&\fBreaction\fR

--- a/reaction/docs/reaction.pod
+++ b/reaction/docs/reaction.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-reaction - Deamon server multithread 
+reaction - Daemon server multithread 
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
## Summary
- fix spelling: `Deamon` -> `Daemon` in reaction docs

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
