### PR TITLE
Fix timeout window message

### DIFF
--- a/estaconn/remoteconn/base/connection.c
+++ b/estaconn/remoteconn/base/connection.c
@@ -207,7 +207,7 @@ void ctrl_eod (int fd_expect)
                		{
 				if (VERBOSE)
 				{
-					printf ("- Maximazing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
+					printf ("- Maximizing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
 				}
 				tv.tv_sec = 0;
                                 tv.tv_usec = MAX_BUFFER_TIMEOUT;

--- a/estaconn/remoteconn/base/remoteconn.c
+++ b/estaconn/remoteconn/base/remoteconn.c
@@ -207,7 +207,7 @@ void ctrl_eod (int fd_expect)
                		{
 				if (VERBOSE)
 				{
-					printf ("- Maximazing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
+					printf ("- Maximizing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
 				}
 				tv.tv_sec = 0;
                                 tv.tv_usec = MAX_BUFFER_TIMEOUT;

--- a/estaconn/remoteconn/base/remoteconn2.c
+++ b/estaconn/remoteconn/base/remoteconn2.c
@@ -205,7 +205,7 @@ char *ctrl_eod (int fd_expect)
         	{
 			if (VERBOSE)
 			{
-				printf ("- Maximazing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
+				printf ("- Maximizing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
 			}
 			tv.tv_sec = 0;
 	       	       	tv.tv_usec = MAX_BUFFER_TIMEOUT;

--- a/estaconn/remoteconn/base/sendcommand.c
+++ b/estaconn/remoteconn/base/sendcommand.c
@@ -207,7 +207,7 @@ void ctrl_eod (int fd_expect)
                		{
 				if (VERBOSE)
 				{
-					printf ("- Maximazing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
+					printf ("- Maximizing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
 				}
 				tv.tv_sec = 0;
                                 tv.tv_usec = MAX_BUFFER_TIMEOUT;

--- a/estaconn/remoteconn/test/remoteconn2.c
+++ b/estaconn/remoteconn/test/remoteconn2.c
@@ -183,7 +183,7 @@ void ctrl_prompt (int fd_expect)
                		}
                		else
                		{
-				printf ("- Maximazing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
+				printf ("- Maximizing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
 				tv.tv_sec = 0;
                                 tv.tv_usec = MAX_BUFFER_TIMEOUT;
 

--- a/estaconn/remoteconn/test/remoteconn4.c
+++ b/estaconn/remoteconn/test/remoteconn4.c
@@ -180,7 +180,7 @@ void ctrl_eod (int fd_expect)
                		}
                		else
                		{
-				printf ("- Maximazing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
+				printf ("- Maximizing timeout window(%d millisec)\n", MAX_BUFFER_TIMEOUT);
 				tv.tv_sec = 0;
                                 tv.tv_usec = MAX_BUFFER_TIMEOUT;
 


### PR DESCRIPTION
## Summary
- fix typo `Maximazing` -> `Maximizing` in remote connection sources and tests

## Testing
- `make -C reaction/docs` *(fails: No rule to make target 'am--refresh')*

------
